### PR TITLE
'day' and relative 'daytime' presets

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -34,6 +34,7 @@
             
             function consoleDate(valueText, inst) {
               var date = new Date(valueText);
+              console.log(inst.getDate());
               console.log(date);
             }
             $('#date1').scroller({ onSelect: consoleDate });
@@ -44,7 +45,14 @@
             // Day
             $('#date4').scroller({ preset: 'day', onSelect: consoleDate });
             // DayTime
-            $('#date5').scroller({ preset: 'daytime', onSelect: consoleDate });
+            $('#date5').scroller({ 
+              theme: 'ios', 
+              preset: 'daytime', 
+              labels: false, 
+              width: 30, 
+              separateWheels: false, 
+              onSelect: consoleDate 
+            });
 
             var group = {};
             var wheels = [group];


### PR DESCRIPTION
acidb, dioslaska,

How's it going? 

I have two new presets I created that may or may not be interesting for you guys. They are 'day' and 'daytime'. 

'day' basically lets you select a date up to seven days in the future. 'daytime' lets you select a date up to seven days in the future and set a time as well. 

Currently, neither has checks to prevent inputs outside that range. I assume in good faith that the original value will be a time between now and +7 days. I haven't figured out if this is necessary or not, or even investigated where in the code is the appropriate place to put such validation logic.

Ultimately, my idea is to move this towards a simple relative interface for dates up to 7 days in the future and the ability to toggle on/off a calendar for dates farther into the future.

Let me know what you think of these modifications and if they are of interest to the project.

Best,
Andrew

PS - What would be great would be a "module" system in Mobiscroll that separates the scroller logic from the presets and associated functions (e.g. getDate, parseDate, etc.). This would make it easy for the community to add new custom modules such as these two I created or other presets such as State or Country selectors and whatnot. It would also allow people to keep the code they serve to the client lean since they would only need to include the modules they are using.
