### PR TITLE
create undefined element (at least on rhino)

### DIFF
--- a/js/mobiscroll.core.js
+++ b/js/mobiscroll.core.js
@@ -471,7 +471,7 @@
         startTime,
         endTime,
         pos,
-        mod = document.createElement(mod).style,
+        mod = document.createElement('modernizr').style,
         has3d = testProps(['perspectiveProperty', 'WebkitPerspective', 'MozPerspective', 'OPerspective', 'msPerspective']) && 'webkitPerspective' in document.documentElement.style,
         prefix = testPrefix(),
         touch = ('ontouchstart' in window),


### PR DESCRIPTION
on line 476, `mod = document.createElement(mod)` generate an exception on rhino when parsing as mod is not defined earlier in script.

reused modernizr initialisation `mod = document.createElement('modernizr')` instead.
