### PR TITLE
Make sure onCancel always fires.

### DIFF
--- a/js/mobiscroll.core.js
+++ b/js/mobiscroll.core.js
@@ -398,6 +398,15 @@
         };
 
         /**
+        * Cancel and hide the scroller instance.
+        */
+        that.cancel = function() {
+            if (that.hide() !== false) {
+                event('onCancel', [that.val]);
+            }
+        };
+
+        /**
         * Changes the values of a wheel, and scrolls to the correct position
         */
         that.changeWheel = function (idx, time) {
@@ -502,9 +511,7 @@
                 });
 
                 $('.dwb-c span', dw).click(function () {
-                    if (that.hide() !== false) {
-                        event('onCancel', [that.val]);
-                    }
+                    that.cancel();
                     return false;
                 });
 

--- a/js/mobiscroll.jqm.js
+++ b/js/mobiscroll.jqm.js
@@ -23,7 +23,7 @@
                 $('.dw', elm).addClass('pop in');
             elm.trigger('create');
             // Hide on overlay click
-            $('.dwo', elm).click(function() { inst.hide(); });
+            $('.dwo', elm).click(function() { inst.cancel(); });
         }
     }
 


### PR DESCRIPTION
mobiscroll.jqm.js calls hide() when the user clicks the underlay, which doesn't
call onCancel.  Fix this so clicking the underlay has the same behavior as clicking
cancel.  Otherwise, there's no way to reliably do things on cancellation, since
you can't tell if it's a cancel or save from onClose (the only event that was being
called before).
