### PR TITLE
Performance improvement for older Android devices

### DIFF
--- a/js/mobiscroll.core.js
+++ b/js/mobiscroll.core.js
@@ -286,8 +286,20 @@
                 i;
 
             callback = callback || empty;
-
-            t.attr('style', (time ? (prefix + '-transition:all ' + time.toFixed(1) + 's ease-out;') : '') + (has3d ? (prefix + '-transform:translate3d(0,' + px + 'px,0);') : ('top:' + px + 'px;')));
+            
+            if (has3d && prefix==='-webkit') {
+	            if (time) {
+	            	t[0].style.webkitTransitionProperty = 'all';
+	            	t[0].style.webkitTransitionDuration = time.toFixed(1) + 's';
+	            	t[0].style.webkitTransitionTimingFunction = 'ease-out';
+		        	t[0].style.webkitTransform = 'translate3d(0,' + px + 'px,0)';
+	            } else {
+	            	t[0].style.webkitTransitionProperty = 'none';
+	            	t[0].style.webkitTransform = 'translate3d(0,' + px + 'px,0)';
+	            }
+            } else {
+	            t.attr('style', (time ? (prefix + '-transition:all ' + time.toFixed(1) + 's ease-out;') : '') + (has3d ? (prefix + '-transform:translate3d(0,' + px + 'px,0);') : ('top:' + px + 'px;')));
+            }
 
             if (iv[index]) {
                 ready();


### PR DESCRIPTION
On older Android devices like e.g. my Google Nexus S the datescroller performs a bit slow and is choppy (maybe due to GC).
Replacing t.attr('style', ...) with setting the style attributes directly (like t[0].style.webkitTransform = ...) makes the animation much smoother on that device. 
