### PR TITLE
Don't add 1 to the width of .dwwr.

### DIFF
--- a/js/mobiscroll.core.js
+++ b/js/mobiscroll.core.js
@@ -145,7 +145,7 @@
                     //}
                 });
                 w = totalw > ww ? minw : totalw;
-                w = $('.dwwr', dw).width(w + 1).outerWidth();
+                w = $('.dwwr', dw).width(w).outerWidth();
                 h = d.outerHeight();
             }
 


### PR DESCRIPTION
This causes an extra pixel of space between .dwwr and .dwc.  If the contents
are centered in .dwwr, this also results in them being off-center by a pixel,
due to the difference in width being odd.  The extra space between the
boxes may also not be wanted by the style.
