### PR TITLE
Translate "unit" and "lap" to Norwegian

### DIFF
--- a/js/i18n/mobiscroll.i18n.no.js
+++ b/js/i18n/mobiscroll.i18n.no.js
@@ -22,7 +22,7 @@
         // Measurement components
         wholeText: 'Hele',
         fractionText: 'Fraksjon',
-        unitText: 'Unit',
+        unitText: 'Enhet',
         // Time / Timespan component
         labels: ['År', 'Måneder', 'Dager', 'Timer', 'Minutter', 'Sekunder', ''],
         labelsShort: ['Yrs', 'Mths', 'Days', 'Hrs', 'Mins', 'Secs', ''],
@@ -30,7 +30,7 @@
         startText: 'Start',
         stopText: 'Stopp',
         resetText: 'Tilbakestille',
-        lapText: 'Lap',
+        lapText: 'Runde',
         hideText: 'Skjul'
     });
 })(jQuery);


### PR DESCRIPTION
These words are, in the context used in MobiScroll, pretty straight forward. If we are talking about measurement units we call this "Enhet" in norwegian. If we are talking about laps taken when running, we call this "Runde".
