### PR TITLE
Multiple selection text.

### DIFF
--- a/js/i18n/mobiscroll.i18n.lt.js
+++ b/js/i18n/mobiscroll.i18n.lt.js
@@ -6,6 +6,7 @@
         cancelText: 'Atšaukti',
         clearText: 'Išvalyti',
         selectedText: 'pasirinktas',
+        selectedPluralText: "pasirinkti"
         // Datetime component
         dateFormat: 'yy.mm.dd',
         dateOrder: 'yymmdd',


### PR DESCRIPTION
Also, for it to be grammatically correct in Lithuanian, it should be "pasirinkti 5" / "selected 5", and as far as I get it's only "5 pasirinkti" / "5 selected". Format i18n for that shouldn't be hard to add I guess?