### PR TITLE
selected text formatting.

### DIFF
--- a/js/mobiscroll.select.js
+++ b/js/mobiscroll.select.js
@@ -446,7 +446,10 @@
                         $.each(selectedValues, function () {
                             length++;
                         });
-                        return length + ' ' + (length > 1 ? s.selectedPluralText || s.selectedText : s.selectedText);
+                        return s.selectedTextFormat.replace(/count/,length).replace(/text/,length>1? s.selectedPluralText || s.selectedText : s.selectedText); 
+                        // Allow formating for selectedtext, as in some languages count goes first.
+                        // Example: selectedTextFormat: "count text", would return "5 selected"
+                        //          selectedTextFormat: "text count", would return "selected 5"
                     };
                 }
 


### PR DESCRIPTION
In some languages "n selected" is grammatically incorrect. That's where user/developer -defined format comes handy.